### PR TITLE
fixing the automap color values for upper row of LEDs

### DIFF
--- a/launchpad_py/launchpad.py
+++ b/launchpad_py/launchpad.py
@@ -511,12 +511,12 @@ class Launchpad( LaunchpadBase ):
 		if number < 0 or number > 7:
 			return
 
-		red   = min( 0, red )
-		red   = max( 7, red )
-		green = min( 0, green )
-		green = max( 7, green )
+		red   = max( 0, red )
+		red   = min( 3, red )
+		green = max( 0, green )
+		green = min( 3, green )
 		led = self.LedGetColor( red, green )
-		
+
 		self.midi.RawWrite( 176, 104 + number, led )
 
 


### PR DESCRIPTION
While trying to change colors of the upper row of LEDs I noticed I am only able to turn them on, and only set to yellow, whatever I try.
Attachted patch fixes that behaviour, it seems there have been some copy&paste errors in the automap method.