### PR TITLE
Fix top-row LEDs.

### DIFF
--- a/launchpad_py/launchpad.py
+++ b/launchpad_py/launchpad.py
@@ -511,10 +511,10 @@ class Launchpad( LaunchpadBase ):
 		if number < 0 or number > 7:
 			return
 
-		red   = min( 0, red )
-		red   = max( 7, red )
-		green = min( 0, green )
-		green = max( 7, green )
+		red   = max( 0, red )
+		red   = min( 7, red )
+		green = max( 0, green )
+		green = min( 7, green )
 		led = self.LedGetColor( red, green )
 		
 		self.midi.RawWrite( 176, 104 + number, led )


### PR DESCRIPTION
The calculation will always result in the maximum as it is, that is, 7, causing the LED to be always on and at full brightness. Fixing this will also allow toggling the top row off again.